### PR TITLE
Add _compute_backscatter() and use it to properly compute ecopuck_bbp 700 (m-1).

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -82,7 +82,8 @@
             //"args": ["--auv_name", "i2map", "--mission", "2021.062.01", "-v", "1"]
             //"args": ["--auv_name", "dorado", "--mission", "2018.079.00", "-v", "1"]
             //"args": ["--auv_name", "i2map", "--mission", "2018.348.01", "-v", "2"]
-            "args": ["--auv_name", "dorado", "--mission", "2023.324.00", "-v", "1", "--plot", "first10000"]
+            //"args": ["--auv_name", "dorado", "--mission", "2023.324.00", "-v", "1", "--plot", "first10000"]
+            "args": ["--auv_name", "dorado", "--mission", "2022.201.00", "-v", "1", "--plot", "first10000"]
         },
         {
             "name": "2.1 - Test hs2_proc.py (its unit tests)",
@@ -136,7 +137,8 @@
             //"args": ["--auv_name", "dorado", "--mission", "2023.192.01", "-v", "1"]
             //"args": ["--auv_name", "i2map", "--mission", "2019.157.02", "-v", "2", "--plot", "--plot_seconds", "82000"],
             //"args": ["--auv_name", "dorado", "--mission", "2021.102.02", "-v", "1", "--flash_threshold", "1.5e10"],
-            "args": ["--auv_name", "dorado", "--mission", "2024.317.01", "-v", "1"],
+            //"args": ["--auv_name", "dorado", "--mission", "2024.317.01", "-v", "1"],
+            "args": ["--auv_name", "dorado", "--mission", "2010.341.00", "-v", "1", "--plot", "--plot_seconds", "82000"],
         },
         {
             "name": "5.0 - archive.py",
@@ -148,7 +150,8 @@
             //"args": ["-v", "1", "--auv_name", "dorado", "--mission", "2017.044.00", "--AUVCTD"],
             //"args": ["-v", "1", "--auv_name", "dorado", "--mission", "2023.192.01", "--AUVCTD"],
             //"args": ["-v", "1", "--auv_name", "i2map", "--mission", "2022.061.01", "--M3", "--AUVCTD"],
-            "args": ["-v", "1", "--auv_name", "dorado", "--mission", "2024.317.01", "--AUVCTD"],
+            //"args": ["-v", "1", "--auv_name", "dorado", "--mission", "2024.317.01", "--AUVCTD"],
+            "args": ["-v", "1", "--auv_name", "dorado", "--mission", "2022.201.00", "--AUVCTD"],
         },
         {
             "name": "6.0 - create_products.py",
@@ -157,7 +160,8 @@
             "program": "${workspaceFolder}/src/data/create_products.py",
             "console": "integratedTerminal",
             //"args": ["-v", "1", "--auv_name", "dorado", "--mission", "2023.192.01", "--local"],
-            "args": ["-v", "2", "--auv_name", "dorado", "--mission", "2016.270.00"],
+            //"args": ["-v", "2", "--auv_name", "dorado", "--mission", "2016.270.00"],
+            "args": ["-v", "1", "--auv_name", "dorado", "--mission", "2022.201.00"],
         },
         {
             "name": "7.0 - email.py",
@@ -220,7 +224,7 @@
             //"args": ["-v", "1", "--last_n_days", "30", "--start_year", "2022", "--end_year", "2022", "--resample", "--noinput"]
             //"args": ["-v", "1", "--last_n_days", "30", "--start_year", "2022", "--end_year", "2022", "--archive", "--noinput"]
             //"args": ["-v", "1", "--start_year", "2021", "--end_year", "2022",  "--noinput"]
-            //"args": ["-v", "1", "--mission", "2022.201.00", "--use_portal",  "--clobber", "--noinput"]
+            "args": ["-v", "1", "--mission", "2022.201.00", "--clobber", "--noinput", "--no_cleanup"]
             //"args": ["-v", "1", "--mission", "2009.084.00",  "--clobber", "--noinput"]
             //"args": ["-v", "1", "--mission", "2022.243.00",  "--calibrate", "--clobber", "--noinput"]
             //"args": ["-v", "1", "--start_year", "2004",  "--end_year", "2004", "--start_yd", "168", "--use_portal", "--clobber", "--noinput"]
@@ -258,7 +262,7 @@
             //"args": ["-v", "1", "--noinput", "--no_cleanup",  "--mission", "2016.090.01", "--resample", "--archive", "--flash_threshold", "3E10"]
             //"args": ["-v", "1", "--noinput", "--num_cores", "8"]
             //"args": ["-v", "1", "--noinput", "--no_cleanup",  "--mission", "2011.256.02", "--clobber"]
-            "args": ["-v", "1", "--noinput", "--no_cleanup",  "--mission", "2010.341.00", "--download_process", "--local"]
+            //"args": ["-v", "1", "--noinput", "--no_cleanup",  "--mission", "2010.341.00", "--download_process", "--local"]
         },
     ]
 }

--- a/src/data/calibrate.py
+++ b/src/data/calibrate.py
@@ -594,6 +594,32 @@ def _beam_transmittance_from_volts(combined_nc, nc) -> tuple[float, float]:
     return Tr, c
 
 
+def _compute_backscatter(wavelength_nm: float, salinity: float, volScat: float):  # noqa: N803
+    # Cribbed from https://mbari.slack.com/archives/C04ETLY6T7V/p1710457297254969?thread_ts=1710348431.316509&cid=C04ETLY6T7V
+    # This is  the same computation used for LRAUV ecopucks. Used here for Dorado ecopuck
+    # following the conversion to "scaled" output using scale_factor and dark counts.
+    theta = 117.0 / 57.29578  # radians
+    d = 0.09
+
+    # These calculations are from the Triplet Puck User's Guide, Revision H
+    Bw = (
+        1.38
+        * (wavelength_nm / 500.0) ** (-4.32)
+        * (1.0 + 0.3 * salinity / 37.0)
+        * 1e-4
+        * (1.0 + np.cos(theta) ** 2.0 * (1.0 - d) / (1.0 + d))
+    )
+    Bp = volScat - Bw
+    if salinity < 35.0:  # noqa: PLR2004
+        bw = 0.0022533 * (wavelength_nm / 500.0) ** (-4.23) * 1e-4
+    else:
+        bw = 0.0029308 * (wavelength_nm / 500.0) ** (-4.24) * 1e-4
+    bbw = bw / 2.0
+    bbp = 2.0 * np.pi * 1.1 * Bp
+
+    return bbw, bbp
+
+
 class SensorInfo:
     pass
 
@@ -2423,7 +2449,7 @@ class Calibrate_NetCDF:
             self.logger.debug("Pausing with plot entitled: %s. Close window to continue.", title)
             plt.show()
 
-        # Save blue, red, & fl to combined_nc, alsoe
+        # Save blue, red, & fl to combined_nc, also
         if hasattr(hs2, "bbp420"):
             self.combined_nc["hs2_bbp420"] = blue_bs
         if hasattr(hs2, "bbp420_fixed"):
@@ -3007,19 +3033,23 @@ class Calibrate_NetCDF:
 
         source = self.sinfo[sensor]["data_filename"]
         coord_str = f"{sensor}_time {sensor}_depth {sensor}_latitude {sensor}_longitude"
+        beta_700 = cf.bbp700_scale_factor * (orig_nc["BB_Sig"].to_numpy() - cf.bbp700_dark_counts)
+        _, bbp = _compute_backscatter(700, 35.2, beta_700)  # Use an average salinity of 35.2
+
         self.combined_nc["ecopuck_bbp700"] = xr.DataArray(
-            cf.bbp700_scale_factor * (orig_nc["BB_Sig"].to_numpy() - cf.bbp700_dark_counts),
+            bbp,
             coords=[orig_nc.get_index("time")],
             dims={f"{sensor}_time"},
             name=f"{sensor}_bbp700",
         )
         self.combined_nc["ecopuck_bbp700"].attrs = {
             "long_name": "Particulate backscattering coefficient at 700 nm",
-            "units": "m^-1 sr^-1",
+            "units": "m-1",
             "coordinates": coord_str,
             "comment": (
-                f"BB_Sig from {source} converted to bbp700 using scale factor "
-                f"{cf.bbp700_scale_factor} and dark counts {cf.bbp700_dark_counts}"
+                f"BB_Sig from {source} converted to beta_700 using scale factor "
+                f"{cf.bbp700_scale_factor} and dark counts {cf.bbp700_dark_counts}, "
+                "then converted to bbp700 by the _compute_backscatter() function."
             ),
         }
 

--- a/src/data/calibrate.py
+++ b/src/data/calibrate.py
@@ -2297,19 +2297,6 @@ class Calibrate_NetCDF:
                 "units": "m-1",
                 "comment": (f"Computed by hs2_calc_bb() from data in {source}"),
             }
-        if hasattr(hs2, "bbp420_fixed"):
-            blue_bs_fixed = xr.DataArray(
-                hs2.bbp420_fixed.to_numpy(),
-                coords=[hs2.bbp420_fixed.get_index("time")],
-                dims={"hs2_time"},
-                name="hs2_bbp420_fixed",
-            )
-            blue_bs_fixed.attrs = {
-                "long_name": "Particulate backscattering coefficient at 420 nm",
-                "coordinates": coord_str,
-                "units": "m-1",
-                "comment": (f"Computed by hs2_calc_bb() from data in {source}"),
-            }
         if hasattr(hs2, "bbp470"):
             blue_bs = xr.DataArray(
                 hs2.bbp470.to_numpy(),
@@ -2346,19 +2333,6 @@ class Calibrate_NetCDF:
                 name="hs2_bbp700",
             )
             red_bs.attrs = {
-                "long_name": "Particulate backscattering coefficient at 700 nm",
-                "coordinates": coord_str,
-                "units": "m-1",
-                "comment": (f"Computed by hs2_calc_bb() from data in {source}"),
-            }
-        if hasattr(hs2, "bbp700_fixed"):
-            red_bs_fixed = xr.DataArray(
-                hs2.bbp700_fixed.to_numpy(),
-                coords=[hs2.bbp700_fixed.get_index("time")],
-                dims={"hs2_time"},
-                name="hs2_bbp700_fixed",
-            )
-            red_bs_fixed.attrs = {
                 "long_name": "Particulate backscattering coefficient at 700 nm",
                 "coordinates": coord_str,
                 "units": "m-1",
@@ -2436,9 +2410,7 @@ class Calibrate_NetCDF:
                 pend = int(self.args.plot.split("first")[1])
             df_plot = pd.DataFrame(index=blue_bs.get_index("hs2_time")[pbeg:pend])
             df_plot["blue_bs"] = blue_bs[pbeg:pend]
-            df_plot["blue_bs_fixed"] = blue_bs_fixed[pbeg:pend]
             df_plot["red_bs"] = red_bs[pbeg:pend]
-            df_plot["red_bs_fixed"] = red_bs_fixed[pbeg:pend]
             ## df_plot["fl"] = fl[pbeg:pend]
             title = (
                 f"First {pend} points from"
@@ -2452,16 +2424,12 @@ class Calibrate_NetCDF:
         # Save blue, red, & fl to combined_nc, also
         if hasattr(hs2, "bbp420"):
             self.combined_nc["hs2_bbp420"] = blue_bs
-        if hasattr(hs2, "bbp420_fixed"):
-            self.combined_nc["hs2_bbp420_fixed"] = blue_bs_fixed
         if hasattr(hs2, "bbp470"):
             self.combined_nc["hs2_bbp470"] = blue_bs
         if hasattr(hs2, "bbp676"):
             self.combined_nc["hs2_bbp676"] = red_bs
         if hasattr(hs2, "bbp700"):
             self.combined_nc["hs2_bbp700"] = red_bs
-        if hasattr(hs2, "bbp700_fixed"):
-            self.combined_nc["hs2_bbp700_fixed"] = red_bs_fixed
         if hasattr(hs2, "fl676"):
             self.combined_nc["hs2_fl676"] = fl
         if hasattr(hs2, "fl700"):


### PR DESCRIPTION
Applies to https://github.com/mbari-org/auv-python/issues/4