### PR TITLE
Save _combined file as .nc4.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -358,11 +358,11 @@
             // Plankitvore deployment for CeNCOOS Syncro - whole month of April 2025
             //"args": ["-v", "1", "--auv_name", "ahi", "--start", "20250401T000000", "--end", "20250502T000000", "--noinput", "--num_cores", "1", "--no_cleanup"]
             // Fails with ValueError: different number of dimensions on data and dims: 2 vs 1 for wetlabsubat_digitized_raw_ad_counts variable
-            //"args": ["-v", "1", "--log_file", "pontus/missionlogs/2025/20250604_20250616/20250608T020852/202506080209_202506081934.nc4", "--no_cleanup"]
+            "args": ["-v", "1", "--log_file", "pontus/missionlogs/2025/20250604_20250616/20250608T020852/202506080209_202506081934.nc4", "--no_cleanup"]
             // Full month of June 2025 for Pontus with WetLabsUBAT Group data
             //"args": ["-v", "1", "--auv_name", "pontus", "--start", "20250601T000000", "--end", "20250702T000000", "--noinput", "--num_cores", "1", "--no_cleanup"]
             //"args": ["-v", "1", "--auv_name", "pontus", "--start", "20250601T000000", "--end", "20250702T000000", "--noinput", "--num_cores", "1", "--no_cleanup", "--clobber"]
-            "args": ["-v", "1", "--log_file", "pontus/missionlogs/2025/20250623_20250707/20250707T043011/slate.nc4", "--no_cleanup"]
+            //"args": ["-v", "1", "--log_file", "pontus/missionlogs/2025/20250623_20250707/20250707T043011/slate.nc4", "--no_cleanup"]
         },
 
     ]

--- a/src/data/align.py
+++ b/src/data/align.py
@@ -428,9 +428,9 @@ class Align_NetCDF:
         return netcdfs_dir
 
     def process_combined(self) -> Path:  # noqa: C901, PLR0912, PLR0915
-        """Process combined LRAUV data from *_combined.nc files created by combine.py"""
+        """Process combined LRAUV data from *_combined.nc4 files created by combine.py"""
         netcdfs_dir = Path(BASE_LRAUV_PATH, f"{Path(self.log_file).parent}")
-        src_file = Path(netcdfs_dir, f"{Path(self.log_file).stem}_combined.nc")
+        src_file = Path(netcdfs_dir, f"{Path(self.log_file).stem}_combined.nc4")
 
         self.combined_nc = xr.open_dataset(src_file)
         self.logger.info("Processing %s", src_file)

--- a/src/data/archive.py
+++ b/src/data/archive.py
@@ -108,7 +108,7 @@ class Archiver:
                 )
                 ftypes = (ft_ending,)
             else:
-                ftypes = (f"{freq}.nc", "cal.nc", "align.nc")
+                ftypes = (f"{freq}.nc", "cal.nc4", "align.nc4")
             for ftype in ftypes:
                 src_file = Path(f"{nc_file_base}_{ftype}")
                 dst_file = Path(surveynetcdfs_dir, src_file.name)

--- a/src/data/combine.py
+++ b/src/data/combine.py
@@ -934,7 +934,7 @@ class Combine_NetCDF:
     def write_netcdf(self) -> None:
         """Write combined netCDF file using instance attributes."""
         netcdfs_dir = Path(BASE_LRAUV_PATH, Path(self.log_file).parent)
-        out_fn = Path(netcdfs_dir, f"{Path(self.log_file).stem}_combined.nc")
+        out_fn = Path(netcdfs_dir, f"{Path(self.log_file).stem}_combined.nc4")
 
         self.combined_nc.attrs = self.global_metadata()
         self.logger.info("Writing combined group data to %s", out_fn)
@@ -945,7 +945,7 @@ class Combine_NetCDF:
             "Data variables written: %s",
             ", ".join(sorted(self.combined_nc.variables)),
         )
-        self.logger.info("Wrote combined (_combined.nc) netCDF file: %s", out_fn)
+        self.logger.info("Wrote combined (_combined.nc4) netCDF file: %s", out_fn)
 
         return netcdfs_dir
 


### PR DESCRIPTION
The variables digitized_raw_ad_counts_M and nudged_time are saved as int64s.

Applies to https://github.com/mbari-org/auv-python/issues/6 and https://github.com/mbari-org/auv-python/issues/56