### PR TITLE
Handle LRAUV log files without GPS data by creating nudged coordinates from dead-reckoned positions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -136,7 +136,9 @@
             // Fails in nudge_positions, maybe bad GPS data?
             //"args": ["-v", "1", "--log_file", "brizo/missionlogs/2025/20250909_20250915/20250911T073640/202509110736_202509120809.nc4", "--plot"]
             // Nudged coordinate is way out of reasonable range - segment 15
-            "args": ["-v", "1", "--log_file", "brizo/missionlogs/2025/20250909_20250915/20250913T080940/202509130809_202509140809.nc4", "--plot"]
+            //"args": ["-v", "1", "--log_file", "brizo/missionlogs/2025/20250909_20250915/20250913T080940/202509130809_202509140809.nc4", "--plot"]
+            // No GPS data for a log_file that has an ESP Sample
+            "args": ["-v", "1", "--log_file", "brizo/missionlogs/2025/20250916_20250922/20250920T070029/202509200700_202509201900.nc4", "--plot"]
 
 
         },
@@ -373,7 +375,7 @@
             // ValueError: Dimension mismatch: wetlabsubat_digitized_raw_ad_counts_time has 33154 elements but wetlabsubat_hv_step_calibration_coefficient_time has 33155 elements
             //"args": ["-v", "1", "--log_file", "pontus/missionlogs/2025/20250623_20250707/20250626T041517/202506260415_202506261400.nc4", "--no_cleanup"]
             // ValueError: coords is not dict-like, but it has 1 items, which does not match the 2 dimensions of the data
-            "args": ["-v", "1", "--log_file", "pontus/missionlogs/2025/20250623_20250707/20250626T140000/202506261400_202506262031.nc4", "--no_cleanup"]
+            //"args": ["-v", "1", "--log_file", "pontus/missionlogs/2025/20250623_20250707/20250626T140000/202506261400_202506262031.nc4", "--no_cleanup"]
             // Full month of June 2025 for Pontus with WetLabsUBAT Group data
             //"args": ["-v", "1", "--auv_name", "pontus", "--start", "20250601T000000", "--end", "20250721T000000", "--no_cleanup"]
             //"args": ["-v", "1", "--auv_name", "pontus", "--start", "20250601T000000", "--end", "20250721T000000", "--noinput", "--num_cores", "1", "--no_cleanup", "--clobber"]
@@ -389,6 +391,8 @@
             //"args": ["-v", "1", "--log_file", "brizo/missionlogs/2025/20250903_20250903/20250903T175939/202509031759_202509032026.nc4", "--no_cleanup"]
             // For loading stoqs_lrauv_sep2025 - which has really bad nav in _2S_scieng.nc files
             //"args": ["-v", "1", "--auv_name", "brizo", "--start", "20250901T000000", "--end", "20251001T000000", "--no_cleanup"]
+            // No GPS data for a log_file that has an ESP Sample
+            "args": ["-v", "1", "--log_file", "brizo/missionlogs/2025/20250916_20250922/20250920T070029/202509200700_202509201900.nc4", "--no_cleanup"]
         },
 
     ]


### PR DESCRIPTION
Modified combine.py to always create nudged_longitude and nudged_latitude variables, even when GPS fixes are unavailable. This allows important log files to proceed through the full processing pipeline (combine → align → resample) to produce _1S.nc files.

Key changes to _add_nudged_coordinates():
- Check for GPS availability before attempting nudging
- Fall back to uncorrected universals_longitude/latitude when GPS is missing or nudging fails
- Add clear warnings in both console logs and metadata attributes
- Include new 'gps_corrected' attribute ("true"/"false") for programmatic detection

When GPS correction cannot be applied:
- Console: WARNING messages alert user during processing
- Metadata: Variable 'comment' includes explicit warning about uncorrected positions
- Metadata: 'gps_corrected' attribute set to "false" for downstream tools to detect

This ensures that scientifically valuable log files (e.g., those with ESP samples) can be processed even without GPS data, while clearly marking the position data quality limitations for end users.

Tested with brizo/missionlogs/2025/20250916_20250922/20250920T070029/202509200700_202509201900.nc4 which has no GPS data but successfully processed through to _1S.nc file.

Kind of still applies to https://github.com/mbari-org/auv-python/issues/6