### PR TITLE
Fix bathymetry polygon folding and depth alignment

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -521,7 +521,9 @@
             // Test engineering plot links
             //"args": ["-v", "1", "--dlist", "ahi/missionlogs/2025/20250128_20250131.dlist", "--update_ssds_provenance", "--force"]
             // Test --build_index for 2026 to test a fixed layout
-            "args": ["-v", "1", "--build_index", "--start", "20260101", "--end", "20261231", "--force"]
+            //"args": ["-v", "1", "--build_index", "--start", "20260101", "--end", "20261231", "--force"]
+            // Test fixing the "folded" bathymetry 
+            "args": ["-v", "1", "--dlist", "ahi/missionlogs/2026/20260218_20260220.dlist", "--force", "--update_ssds_provenance", "--notify", "mccann@mbari.org"]
 
         },
 

--- a/src/data/create_products.py
+++ b/src/data/create_products.py
@@ -1031,7 +1031,7 @@ class CreateProducts:
             max_depth = max(np.floor(np.nanmax(depths_with_data) / 10) * 10, 10)
         else:
             max_depth = max(np.floor(np.nanmax(depth_values) / 10) * 10, 10)
-        iz = np.arange(0, max_depth, 0.5)
+        iz = np.arange(0, max_depth + 0.5, 0.5)  # include max_depth so axis reaches it
 
         return idist, iz, distnav
 
@@ -1927,16 +1927,21 @@ class CreateProducts:
         # Add bathymetry as grey filled contour if available
         if bottom_depths is not None:
             dist_km = distnav.to_numpy() / 1000.0
+            # get_yticks() includes the locator's "next nice step" beyond the view
+            # limit, matching the deepest tick label the user sees (e.g. 300 m
+            # when the view limit is 280 m and the tick step is 50 m).
+            y_max = max(curr_ax.get_yticks())
+            capped = np.fmin(bottom_depths, y_max)
             xb_bathy = np.append(
                 dist_km,
                 [curr_ax.get_xlim()[1], curr_ax.get_xlim()[1], curr_ax.get_xlim()[0], dist_km[0]],
             )
             yb_bathy = np.append(
-                bottom_depths,
-                [bottom_depths[-1], curr_ax.get_ylim()[0], curr_ax.get_ylim()[0], bottom_depths[0]],
+                capped,
+                [capped[-1], y_max, y_max, capped[0]],
             )
             try:
-                curr_ax.fill(xb_bathy, yb_bathy, color="#CCCCCC", zorder=1, alpha=0.8)
+                curr_ax.fill(xb_bathy, yb_bathy, color="#CCCCCC", zorder=1, alpha=0.8, lw=0)
             except ValueError as e:
                 self.logger.warning("Could not fill bathymetry area: %s", e)  # noqa: TRY400
 
@@ -2195,19 +2200,18 @@ class CreateProducts:
 
         # Add bathymetry as grey filled contour if available
         if bottom_depths is not None:
-            # Pair bottom_depths with distance along track
             dist_km = distnav.to_numpy() / 1000.0
-            # Create polygon for seafloor: from left to right along bottom,
-            # then back along axis bottom
+            y_max = max(curr_ax.get_yticks())
+            capped = np.fmin(bottom_depths, y_max)
             xb_bathy = np.append(
                 dist_km,
                 [curr_ax.get_xlim()[1], curr_ax.get_xlim()[1], curr_ax.get_xlim()[0], dist_km[0]],
             )
             yb_bathy = np.append(
-                bottom_depths,
-                [bottom_depths[-1], curr_ax.get_ylim()[0], curr_ax.get_ylim()[0], bottom_depths[0]],
+                capped,
+                [capped[-1], y_max, y_max, capped[0]],
             )
-            curr_ax.fill(xb_bathy, yb_bathy, color="#CCCCCC", zorder=1, alpha=0.8)
+            curr_ax.fill(xb_bathy, yb_bathy, color="#CCCCCC", zorder=1, alpha=0.8, lw=0)
 
         # Add measurement location dots for density plot
         if var == "density":

--- a/src/data/lrauv_deployment_plots.py
+++ b/src/data/lrauv_deployment_plots.py
@@ -427,7 +427,19 @@ class DeploymentPlotter:
             group = href.split("/")[0] if "/" in href else ""
             grouped.setdefault(group, []).append(href)
 
-        max_cols = max((len(hrefs) for hrefs in grouped.values()), default=1)
+        def _col_index(href: str) -> int:
+            return next(
+                (i for i, k in enumerate(self._PLOT_COLUMN_ORDER) if k in href),
+                len(self._PLOT_COLUMN_ORDER),
+            )
+
+        max_cols = (
+            max(
+                (_col_index(href) for hrefs in grouped.values() for href in hrefs),
+                default=0,
+            )
+            + 1
+        )
         col_width = f"{100 // max_cols}%"
         body = ""
         for group in sorted(grouped):
@@ -435,13 +447,7 @@ class DeploymentPlotter:
             body += f'<h2 id="{group}">{label}</h2>\n'
             body += '<table width="100%">\n<tr>\n'
             # Map each known href to its column index so gaps produce blank cells.
-            col_map: dict[int, str] = {}
-            for href in grouped[group]:
-                col = next(
-                    (i for i, k in enumerate(self._PLOT_COLUMN_ORDER) if k in href),
-                    len(self._PLOT_COLUMN_ORDER),
-                )
-                col_map[col] = href
+            col_map: dict[int, str] = {_col_index(href): href for href in grouped[group]}
             for col in range(max_cols):
                 href = col_map.get(col)
                 if href is None:


### PR DESCRIPTION
Seafloor depths exceeding the plot axis caused self-intersecting
polygons (visible as folded/flipped grey areas). Cap depths to the
axis bottom using np.fmin (NaN-safe) before building the polygon, and
close the polygon at max(get_yticks()) — the deepest rendered tick
label — rather than get_ylim()[0], which stops short of the displayed
axis maximum. Also extend iz to include max_depth so set_ylim reaches
the rounded tick value exactly. Suppress the polygon edge with lw=0
to eliminate a hairline artifact at the capped boundary.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>