### PR TITLE
Drop <auv_name> suffix from all the file names.

### DIFF
--- a/src/data/lrauv_deployment_plots.py
+++ b/src/data/lrauv_deployment_plots.py
@@ -408,6 +408,10 @@ class DeploymentPlotter:
             content = index_path.read_text()
             all_hrefs = set(re.findall(r'href="([^"#][^"]*\.html)"', content))
             group_names = dict(re.findall(r'<h2 id="([^"]+)">([^<]+)</h2>', content))
+            # Drop hrefs whose filename has a prefix before the group name (old auv_name_ style).
+            all_hrefs = {
+                h for h in all_hrefs if "/" not in h or Path(h).name.startswith(h.split("/")[0])
+            }
             # clobber=True drops only this deployment's existing entries so they are rebuilt;
             # other deployments' entries are always preserved.
             known_hrefs = (
@@ -867,13 +871,10 @@ class DeploymentPlotter:
     def _other_plots_line(
         self,
         nt: str,
-        sibling_html_paths: list[Path] | None,
         other_png_paths: list[str] | None,
     ) -> str:
         """Return an HTML paragraph linking to sibling deployment plots, or empty string."""
-        if sibling_html_paths:
-            links = [f'<a href="{p.name}" {nt}>{p.stem}.png</a>' for p in sibling_html_paths]
-        elif other_png_paths:
+        if other_png_paths:
             links = [
                 f'<a href="{Path(p).with_suffix(".html").name}" {nt}>{Path(p).name}</a>'
                 for p in other_png_paths
@@ -897,7 +898,6 @@ class DeploymentPlotter:
         png_file_path: Path | None = None,
         other_png_paths: list[str] | None = None,
         nc_durations: dict[str, int] | None = None,
-        sibling_html_paths: list[Path] | None = None,
     ) -> None:
         """Write a plain HTML page for one deployment PNG.
 
@@ -975,7 +975,7 @@ class DeploymentPlotter:
             "  </table>\n"
         )
 
-        other_plots_line = self._other_plots_line(nt, sibling_html_paths, other_png_paths)
+        other_plots_line = self._other_plots_line(nt, other_png_paths)
 
         stoqs_line = ""
         if stoqs_url:

--- a/src/data/process_lrauv_sbd.py
+++ b/src/data/process_lrauv_sbd.py
@@ -254,14 +254,14 @@ def _make_products(
     output_dir = out_paths[0].parent.parent  # YYYYMM directory
     ds, month_files = _concat_month_files(output_dir)
 
-    monthly_png = output_dir / f"{args.auv_name}_{output_dir.name}_sbd_{FREQ}_2column_cmocean.png"
+    monthly_png = output_dir / f"{output_dir.name}_sbd_{FREQ}_2column_cmocean.png"
     if monthly_png.exists() and not args.clobber:
         newest_nc = max(p.stat().st_mtime for p in month_files)
         if newest_nc <= monthly_png.stat().st_mtime:
             logger.info("Monthly plots up to date for %s — skipping", output_dir.name)
             return
 
-    plot_stem = f"{args.auv_name}_{output_dir.name}_sbd"
+    plot_stem = f"{output_dir.name}_sbd"
     cp = CreateProducts(
         auv_name=args.auv_name,
         mission=mission,
@@ -309,10 +309,7 @@ def _make_products(
                     nc_durations[url] = int(
                         (times[-1] - times[0]).astype("timedelta64[m]").astype(int)
                     )
-        html_paths = [
-            png_path.with_name(f"{png_path.stem.removeprefix(f'{args.auv_name}_')}.html")
-            for png_path in png_paths
-        ]
+        html_paths = [p.with_suffix(".html") for p in png_paths]
         for png_path, html_path in zip(png_paths, html_paths, strict=True):
             dp._write_per_png_html(
                 html_path=html_path,
@@ -323,7 +320,7 @@ def _make_products(
                 nc_files=nc_file_strs,
                 auv_name=args.auv_name,
                 png_file_path=png_path,
-                sibling_html_paths=[p for p in html_paths if p != html_path],
+                other_png_paths=[str(p) for p in png_paths if p != png_path],
                 nc_durations=nc_durations,
             )
 
@@ -331,6 +328,7 @@ def _make_products(
             output_dir,
             html_paths,
             deployment_name=f"{args.auv_name} {output_dir.name}",
+            clobber=True,
         )
 
 


### PR DESCRIPTION
This makes it easier to simply replace one instance of an `auv_name` in the url to view plots for another vehicle.

Applies to https://github.com/mbari-org/auv-python/issues/180.