### PR TITLE
Add more detail to the log message for rejected time values.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -487,7 +487,9 @@
             // Test having a better y-max that puts data instead of white space at the bottom
             //"args": ["-v", "1", "--log_file", "ahi/missionlogs/2026/20260406_20260412/20260410T010521/202604100105_202604100800.nc4"]
             // Test processing only new data - as we would do in production with a cron job
-            "args": ["-v", "1", "--last_n_days", "14"]
+            //"args": ["-v", "1", "--last_n_days", "14"]
+            // Test improving out of range log message for Planktivore deployment in April 2026 - Ahi 47 CFE
+            "args": ["-v", "1", "--log_file", "ahi/missionlogs/2026/20260406_20260412/20260410T080016/202604100800_202604111036.nc4", "--clobber"]
         },
         {
             "name": "process_lrauv_sbd",

--- a/src/data/nc42netcdfs.py
+++ b/src/data/nc42netcdfs.py
@@ -806,14 +806,35 @@ class Extract:
 
         if outliers_found > 0:
             non_finite = np.sum(~is_finite)
-            out_of_range = np.sum(~is_in_range & is_finite)
+            out_of_range_mask = ~is_in_range & is_finite
+            out_of_range = np.sum(out_of_range_mask)
 
+            win_start = datetime.fromtimestamp(MIN_UNIX_TIME, tz=UTC).strftime("%Y-%m-%dT%H:%MZ")
+            win_end = datetime.fromtimestamp(MAX_UNIX_TIME, tz=UTC).strftime("%Y-%m-%dT%H:%MZ")
             self.logger.info(
                 "Pre-filtered %d invalid time values: %d non-finite, %d out-of-range",
                 outliers_found,
                 non_finite,
                 out_of_range,
             )
+            self.logger.info("  Valid window : [%s ──── %s]", win_start, win_end)
+            if out_of_range:
+                bad = time_array[out_of_range_mask]
+                bad_start = datetime.fromtimestamp(bad.min(), tz=UTC).strftime("%Y-%m-%dT%H:%MZ")
+                bad_end = datetime.fromtimestamp(bad.max(), tz=UTC).strftime("%Y-%m-%dT%H:%MZ")
+                before = np.sum(bad < MIN_UNIX_TIME)
+                after = np.sum(bad > MAX_UNIX_TIME)
+                parts = []
+                if before:
+                    parts.append(f"{before} before")
+                if after:
+                    parts.append(f"{after} after")
+                self.logger.info(
+                    "  Rejected     : [%s ──── %s]  (%s window)",
+                    bad_start,
+                    bad_end,
+                    ", ".join(parts),
+                )
 
         return valid_indices
 


### PR DESCRIPTION
This improves diagnostics for analyzing time offsets from, e.g. from Planktivore.